### PR TITLE
Added Value API's

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -102,14 +102,24 @@ func (m *Mutex) UnlockWithValue(value string) bool {
 	return n >= m.quorum
 }
 
-// Extend resets the mutex's expiry and returns the status of expiry extension. It is a run-time error if m is not locked on entry to Extend.
+// Extend resets the mutex's expiry and returns the status of expiry
+// extension. It is a run-time error if m is not locked on entry to Extend.
 func (m *Mutex) Extend() bool {
-	m.nodem.Lock()
-	defer m.nodem.Unlock()
+	m.nodem.RLock()
+	defer m.nodem.RUnlock()
+
+	return m.ExtendWithValue(m.value)
+}
+
+// ExtendWithValue resets the mutex's expiry and returns the status of expiry
+// extension. It is a run-time error if m is not locked on entry to Extend.
+func (m *Mutex) ExtendWithValue(value string) bool {
+	m.nodem.RLock()
+	defer m.nodem.RUnlock()
 
 	n := 0
 	for _, pool := range m.pools {
-		ok := m.touch(pool, m.value, int(m.expiry/time.Millisecond))
+		ok := m.touch(pool, value, int(m.expiry/time.Millisecond))
 		if ok {
 			n++
 		}

--- a/mutex.go
+++ b/mutex.go
@@ -43,7 +43,7 @@ func (m *Mutex) Lock() error {
 		if i != 0 {
 			time.Sleep(m.delay)
 		}
-		
+
 		start := time.Now()
 
 		n := 0
@@ -96,6 +96,11 @@ func (m *Mutex) Extend() bool {
 		}
 	}
 	return n >= m.quorum
+}
+
+// Value returns the current value associated with m.
+func (m *Mutex) Value() string {
+	return m.value
 }
 
 func (m *Mutex) genValue() (string, error) {

--- a/mutex.go
+++ b/mutex.go
@@ -24,7 +24,7 @@ type Mutex struct {
 	value string
 	until time.Time
 
-	nodem sync.Mutex
+	nodem sync.RWMutex
 
 	pools []Pool
 }
@@ -77,10 +77,20 @@ func (m *Mutex) LockWithValue(value string) error {
 	return ErrFailed
 }
 
-// Unlock unlocks m and returns the status of unlock. It is a run-time error if m is not locked on entry to Unlock.
+// Unlock unlocks m and returns the status of unlock. It is a run-time error if
+// m is not locked on entry to Unlock.
 func (m *Mutex) Unlock() bool {
-	m.nodem.Lock()
-	defer m.nodem.Unlock()
+	m.nodem.RLock()
+	defer m.nodem.RUnlock()
+
+	return m.UnlockWithValue(m.value)
+}
+
+// UnlockWithValue unlocks m and returns the status of unlock. It is a run-time
+// error if m is not locked on entry to Unlock.
+func (m *Mutex) UnlockWithValue(value string) bool {
+	m.nodem.RLock()
+	defer m.nodem.RUnlock()
 
 	n := 0
 	for _, pool := range m.pools {

--- a/mutex.go
+++ b/mutex.go
@@ -29,15 +29,24 @@ type Mutex struct {
 	pools []Pool
 }
 
-// Lock locks m. In case it returns an error on failure, you may retry to acquire the lock by calling this method again.
+// Lock locks m. In case it returns an error on failure, you may retry to
+// acquire the lock by calling this method again. It will generate a value
+// randomly.
 func (m *Mutex) Lock() error {
-	m.nodem.Lock()
-	defer m.nodem.Unlock()
-
-	value, err := m.genValue()
+	value, err := GenValue()
 	if err != nil {
 		return err
 	}
+
+	return m.LockWithValue(value)
+}
+
+// LockWithValue locks m with the given value. In case it returns an error on
+// failure, you may retry to acquire the lock by calling this method again. It
+// will generate a value randomly.
+func (m *Mutex) LockWithValue(value string) error {
+	m.nodem.Lock()
+	defer m.nodem.Unlock()
 
 	for i := 0; i < m.tries; i++ {
 		if i != 0 {
@@ -103,7 +112,8 @@ func (m *Mutex) Value() string {
 	return m.value
 }
 
-func (m *Mutex) genValue() (string, error) {
+// GenValue will generate a value for use with `LockWithValue`.
+func GenValue() (string, error) {
 	b := make([]byte, 32)
 	_, err := rand.Read(b)
 	if err != nil {

--- a/redsync.go
+++ b/redsync.go
@@ -71,3 +71,10 @@ func SetDriftFactor(factor float64) Option {
 		m.factor = factor
 	})
 }
+
+// SetValue sets the value of the mutex.
+func SetValue(value string) Option {
+	return OptionFunc(func(m *Mutex) {
+		m.value = value
+	})
+}

--- a/redsync.go
+++ b/redsync.go
@@ -71,10 +71,3 @@ func SetDriftFactor(factor float64) Option {
 		m.factor = factor
 	})
 }
-
-// SetValue sets the value of the mutex.
-func SetValue(value string) Option {
-	return OptionFunc(func(m *Mutex) {
-		m.value = value
-	})
-}


### PR DESCRIPTION
This allows a distributed lock to be shared and checked across many application instances over many http/other requests if the value is a predictable pattern.

My use case was that I wanted to lock a resource after a specific http request was received, and I was to unlock it after another separate request was received. The Value/SetValue api's allows just that, predictable locks that can be regenerated so that the mutex lock/unlock state can be adjusted on later requests.

Open to discussion!