### PR TITLE
Add LockWithValue

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -73,16 +73,12 @@ func (m *Mutex) Lock() error {
 
 // Unlock unlocks m and returns the status of unlock.
 func (m *Mutex) Unlock() bool {
-	return m.UnlockWithValue(m.value)
-}
-
-func (m *Mutex) UnlockWithValue(value string) bool {
 	m.nodem.Lock()
 	defer m.nodem.Unlock()
 
 	n := 0
 	for _, pool := range m.pools {
-		ok := m.release(pool, value)
+		ok := m.release(pool, m.value)
 		if ok {
 			n++
 		}

--- a/mutex.go
+++ b/mutex.go
@@ -29,15 +29,9 @@ type Mutex struct {
 	pools []Pool
 }
 
-// Lock locks m. In case it returns an error on failure, you may retry to acquire the lock by calling this method again.
-func (m *Mutex) Lock() (value string, err error) {
+func (m *Mutex) LockWithValue(value string) (string, error) {
 	m.nodem.Lock()
 	defer m.nodem.Unlock()
-
-	value, err = m.genValue()
-	if err != nil {
-		return "", err
-	}
 
 	for i := 0; i < m.tries; i++ {
 		if i != 0 {
@@ -66,6 +60,15 @@ func (m *Mutex) Lock() (value string, err error) {
 	}
 
 	return "", ErrFailed
+}
+
+// Lock locks m. In case it returns an error on failure, you may retry to acquire the lock by calling this method again.
+func (m *Mutex) Lock() (value string, err error) {
+	value, err = m.genValue()
+	if err != nil {
+		return "", err
+	}
+	return m.LockWithValue(value)
 }
 
 // Unlock unlocks m and returns the status of unlock.

--- a/mutex.go
+++ b/mutex.go
@@ -29,7 +29,7 @@ type Mutex struct {
 	pools []Pool
 }
 
-func (m *Mutex) LockWithValue(value string) (string, error) {
+func (m *Mutex) LockWithValue(value string) error {
 	m.nodem.Lock()
 	defer m.nodem.Unlock()
 
@@ -52,21 +52,21 @@ func (m *Mutex) LockWithValue(value string) (string, error) {
 		if n >= m.quorum && time.Now().Before(until) {
 			m.value = value
 			m.until = until
-			return value, nil
+			return nil
 		}
 		for _, pool := range m.pools {
 			m.release(pool, value)
 		}
 	}
 
-	return "", ErrFailed
+	return ErrFailed
 }
 
 // Lock locks m. In case it returns an error on failure, you may retry to acquire the lock by calling this method again.
-func (m *Mutex) Lock() (value string, err error) {
-	value, err = m.genValue()
+func (m *Mutex) Lock() error {
+	value, err := m.genValue()
 	if err != nil {
-		return "", err
+		return err
 	}
 	return m.LockWithValue(value)
 }


### PR DESCRIPTION
This is to address https://github.com/hjr265/redsync.go/issues/14

Basically by allowing the user to supply the value instead of generating it, this can be useful to re-acquire a lock if the process that is holding the lock restarts and is not able to re-aquire a lock because it does not know the value. 