### PR TITLE
Update redigo import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install Redsync using the go get command:
 
     $ go get gopkg.in/redsync.v1
 
-The only dependencies are the Go distribution and [Redigo](https://github.com/garyburd/redigo).
+The only dependencies are the Go distribution and [Redigo](https://github.com/gomodule/redigo).
 
 ## Documentation
 

--- a/mutex.go
+++ b/mutex.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 )
 
 // A Mutex is a distributed mutual exclusion lock.
@@ -43,7 +43,7 @@ func (m *Mutex) Lock() error {
 		if i != 0 {
 			time.Sleep(m.delay)
 		}
-		
+
 		start := time.Now()
 
 		n := 0

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/garyburd/redigo/redis"
+	"github.com/gomodule/redigo/redis"
 	"github.com/stvp/tempredis"
 )
 

--- a/redis.go
+++ b/redis.go
@@ -1,6 +1,6 @@
 package redsync
 
-import "github.com/garyburd/redigo/redis"
+import "github.com/gomodule/redigo/redis"
 
 // A Pool maintains a pool of Redis connections.
 type Pool interface {


### PR DESCRIPTION
The repository github.com/garyburd/redigo has moved to github.com/gomodule/redigo, so update the import paths and README link.