### PR TITLE
Give the user an option to control the delay

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -9,8 +9,8 @@ import (
 	"github.com/gomodule/redigo/redis"
 )
 
-// A DelayFunc is used to wait for a while between retries
-type DelayFunc func(tries int)
+// A DelayFunc is used to decide the amount of time to wait between retries.
+type DelayFunc func(tries int) time.Duration
 
 // A Mutex is a distributed mutual exclusion lock.
 type Mutex struct {
@@ -44,7 +44,7 @@ func (m *Mutex) Lock() error {
 
 	for i := 0; i < m.tries; i++ {
 		if i != 0 {
-			m.delayFunc(i)
+			time.Sleep(m.delayFunc(i))
 		}
 
 		start := time.Now()

--- a/mutex.go
+++ b/mutex.go
@@ -9,13 +9,16 @@ import (
 	"github.com/gomodule/redigo/redis"
 )
 
+// A DelayFunc is used to wait for a while between retries
+type DelayFunc func(tries int)
+
 // A Mutex is a distributed mutual exclusion lock.
 type Mutex struct {
 	name   string
 	expiry time.Duration
 
-	tries int
-	delay time.Duration
+	tries     int
+	delayFunc DelayFunc
 
 	factor float64
 
@@ -41,7 +44,7 @@ func (m *Mutex) Lock() error {
 
 	for i := 0; i < m.tries; i++ {
 		if i != 0 {
-			time.Sleep(m.delay)
+			m.delayFunc(i)
 		}
 
 		start := time.Now()

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -154,13 +154,13 @@ func newTestMutexes(pools []Pool, name string, n int) []*Mutex {
 	mutexes := []*Mutex{}
 	for i := 0; i < n; i++ {
 		mutexes = append(mutexes, &Mutex{
-			name:   name,
-			expiry: 8 * time.Second,
-			tries:  32,
-			delay:  500 * time.Millisecond,
-			factor: 0.01,
-			quorum: len(pools)/2 + 1,
-			pools:  pools,
+			name:      name,
+			expiry:    8 * time.Second,
+			tries:     32,
+			delayFunc: func(tries int) { time.Sleep(500 * time.Millisecond) },
+			factor:    0.01,
+			quorum:    len(pools)/2 + 1,
+			pools:     pools,
 		})
 	}
 	return mutexes

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -157,7 +157,7 @@ func newTestMutexes(pools []Pool, name string, n int) []*Mutex {
 			name:      name,
 			expiry:    8 * time.Second,
 			tries:     32,
-			delayFunc: func(tries int) { time.Sleep(500 * time.Millisecond) },
+			delayFunc: func(tries int) time.Duration { return 500 * time.Millisecond },
 			factor:    0.01,
 			quorum:    len(pools)/2 + 1,
 			pools:     pools,

--- a/redsync.go
+++ b/redsync.go
@@ -20,7 +20,7 @@ func (r *Redsync) NewMutex(name string, options ...Option) *Mutex {
 		name:      name,
 		expiry:    8 * time.Second,
 		tries:     32,
-		delayFunc: func(tries int) { time.Sleep(500 * time.Millisecond) },
+		delayFunc: func(tries int) time.Duration { return 500 * time.Millisecond },
 		factor:    0.01,
 		quorum:    len(r.pools)/2 + 1,
 		pools:     r.pools,
@@ -61,14 +61,13 @@ func SetTries(tries int) Option {
 // SetRetryDelay can be used to set the amount of time to wait between retries.
 func SetRetryDelay(delay time.Duration) Option {
 	return OptionFunc(func(m *Mutex) {
-		m.delayFunc = func(tries int) {
-			time.Sleep(delay)
+		m.delayFunc = func(tries int) time.Duration {
+			return delay
 		}
 	})
 }
 
 // SetRetryDelayFunc can be used to set the DelayFunc.
-// The DelayFunc is used to wait for a while between retries.
 func SetRetryDelayFunc(delayFunc DelayFunc) Option {
 	return OptionFunc(func(m *Mutex) {
 		m.delayFunc = delayFunc

--- a/redsync.go
+++ b/redsync.go
@@ -17,13 +17,13 @@ func New(pools []Pool) *Redsync {
 // NewMutex returns a new distributed mutex with given name.
 func (r *Redsync) NewMutex(name string, options ...Option) *Mutex {
 	m := &Mutex{
-		name:   name,
-		expiry: 8 * time.Second,
-		tries:  32,
-		delay:  500 * time.Millisecond,
-		factor: 0.01,
-		quorum: len(r.pools)/2 + 1,
-		pools:  r.pools,
+		name:      name,
+		expiry:    8 * time.Second,
+		tries:     32,
+		delayFunc: func(tries int) { time.Sleep(500 * time.Millisecond) },
+		factor:    0.01,
+		quorum:    len(r.pools)/2 + 1,
+		pools:     r.pools,
 	}
 	for _, o := range options {
 		o.Apply(m)
@@ -61,7 +61,17 @@ func SetTries(tries int) Option {
 // SetRetryDelay can be used to set the amount of time to wait between retries.
 func SetRetryDelay(delay time.Duration) Option {
 	return OptionFunc(func(m *Mutex) {
-		m.delay = delay
+		m.delayFunc = func(tries int) {
+			time.Sleep(delay)
+		}
+	})
+}
+
+// SetRetryDelayFunc can be used to set the DelayFunc.
+// The DelayFunc is used to wait for a while between retries.
+func SetRetryDelayFunc(delayFunc DelayFunc) Option {
+	return OptionFunc(func(m *Mutex) {
+		m.delayFunc = delayFunc
 	})
 }
 


### PR DESCRIPTION
For example，I want the clien try again after a random delay in order to try to desynchronize multiple clients trying to acquire the lock for the same resource at the same time , I can just add this:
```
SetRetryDelayFunc(func(tries int) time.Duration {
	randomDelay := time.Duration(rand.Intn(100)) * time.Millisecond
	return 500*time.Millisecond + randomDelay
})
```
Or I want to make a backoff,I can do this:
```
SetRetryDelayFunc(func(tries int) time.Duration {
	if tries == 0 {
		return time.Duration(0)
	}
	return time.Duration(math.Pow(10, float64(tries))) * time.Millisecond
})
```