### PR TITLE
Update tempredis to remove reference to garyburd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/go-redsync/redsync
 
 require (
-	github.com/garyburd/redigo v2.0.0+incompatible // indirect
 	github.com/gomodule/redigo v2.0.0+incompatible
-	github.com/stvp/tempredis v0.0.0-20160122230306-83f7aae7ea49
+	github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/garyburd/redigo v2.0.0+incompatible h1:Gb5TnQbf/SfRTYd07ZgodtGEDhNOviGCxoyZnyBDuNU=
-github.com/garyburd/redigo v2.0.0+incompatible/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
-github.com/stvp/tempredis v0.0.0-20160122230306-83f7aae7ea49 h1:aBiMfOQ47GCfoTbNcnVyph/dnUuTWN0rSqEKFq3T58Y=
-github.com/stvp/tempredis v0.0.0-20160122230306-83f7aae7ea49/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=
+github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
+github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=


### PR DESCRIPTION
Update to latest commit of `stvp/tempredis` which remove reference to `garyburd/redigo`

Resolves https://github.com/go-redsync/redsync/issues/26