### PR TITLE
Added new error type: ErrLockAlreadyAcquired

### DIFF
--- a/error.go
+++ b/error.go
@@ -3,3 +3,4 @@ package redsync
 import "errors"
 
 var ErrFailed = errors.New("redsync: failed to acquire lock")
+var ErrLockAlreadyAcquired = errors.New("redsync: lock is already acquired")

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -75,10 +75,28 @@ func TestMutexQuorum(t *testing.T) {
 			assertAcquired(t, pools, mutex)
 		} else {
 			err := mutex.Lock()
-			if err != ErrFailed {
+			if err != ErrFailed && err != ErrLockAlreadyAcquired {
 				t.Fatalf("Expected err == %q, got %q", ErrFailed, err)
 			}
 		}
+	}
+}
+
+func TestIsLockAlreadyAcquired(t *testing.T) {
+	pools := newMockPools(8)
+	rs := New(pools)
+
+	mutex1 := rs.NewMutex("test-shared-lock", SetExpiry(time.Hour))
+	err := mutex1.Lock()
+	if err != nil {
+		t.Error("Expected nil, got: ", err)
+	}
+	assertAcquired(t, pools, mutex1)
+
+	mutex2 := rs.NewMutex("test-shared-lock")
+	err = mutex2.Lock()
+	if err != ErrLockAlreadyAcquired {
+		t.Fatalf("Expected err == %q, got %q", ErrLockAlreadyAcquired, err)
 	}
 }
 


### PR DESCRIPTION
In some cases it's important to know, why lock can not to be acquired: it is technical problem (e.g. redis is unawailable) or lock is already acquired by another process.

I added new type of error to distinguish such cases.