### PR TITLE
fix bug in Extend() and Unlock()

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -105,8 +105,9 @@ var deleteScript = redis.NewScript(1, `
 func (m *Mutex) release(pool Pool, value string) bool {
 	conn := pool.Get()
 	defer conn.Close()
-	status, err := deleteScript.Do(conn, m.name, value)
-	return err == nil && status != int64(0)
+	status, err := redis.Int64(deleteScript.Do(conn, m.name, value))
+
+	return err == nil && status != 0
 }
 
 var touchScript = redis.NewScript(1, `
@@ -120,8 +121,9 @@ var touchScript = redis.NewScript(1, `
 func (m *Mutex) touch(pool Pool, value string, expiry int) bool {
 	conn := pool.Get()
 	defer conn.Close()
-	status, err := touchScript.Do(conn, m.name, value, expiry)
-	return err == nil && status != int64(0)
+	status, err := redis.Int64(touchScript.Do(conn, m.name, value, expiry))
+
+	return err == nil && status != 0
 }
 
 func (m *Mutex) actOnPoolsAsync(actFn func(Pool) bool) int {

--- a/mutex.go
+++ b/mutex.go
@@ -106,7 +106,7 @@ func (m *Mutex) release(pool Pool, value string) bool {
 	conn := pool.Get()
 	defer conn.Close()
 	status, err := deleteScript.Do(conn, m.name, value)
-	return err == nil && status != 0
+	return err == nil && status != int64(0)
 }
 
 var touchScript = redis.NewScript(1, `
@@ -121,7 +121,7 @@ func (m *Mutex) touch(pool Pool, value string, expiry int) bool {
 	conn := pool.Get()
 	defer conn.Close()
 	status, err := touchScript.Do(conn, m.name, value, expiry)
-	return err == nil && status != 0
+	return err == nil && status != int64(0)
 }
 
 func (m *Mutex) actOnPoolsAsync(actFn func(Pool) bool) int {


### PR DESCRIPTION
now the functions returns true for expired keys, because `func (s *Script) Do(c Conn, keysAndArgs ...interface{}) (interface{}, error)` return int64(0) [(link)](https://github.com/gomodule/redigo/blob/master/redis/conn.go#L510) and  `interface{int64(0)} != 0` return true.

I'm converting 0 to int64