### PR TITLE
Providing a 'check' to ensure a lock is still valid prior to writing.

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -78,6 +78,20 @@ func (m *Mutex) Extend() bool {
 	return n >= m.quorum
 }
 
+func (m *Mutex) Valid() bool {
+	n := m.actOnPoolsAsync(func(pool Pool) bool {
+		return m.valid(pool)
+	})
+	return n >= m.quorum
+}
+
+func (m *Mutex) valid(pool Pool) bool {
+	conn := pool.Get()
+	defer conn.Close()
+	reply, err := redis.String(conn.Do("GET", m.name))
+	return err == nil && m.value == reply
+}
+
 func genValue() (string, error) {
 	b := make([]byte, 16)
 	_, err := rand.Read(b)

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -116,6 +116,29 @@ func TestMutexFailure(t *testing.T) {
 	assertAcquired(t, okayPools, mutex)
 }
 
+func TestValid(t *testing.T) {
+	pools := newMockPools(8, servers)
+	rs := New(pools)
+	key := "test-shared-lock"
+
+	mutex1 := rs.NewMutex(key, SetExpiry(time.Hour))
+	err := mutex1.Lock()
+	if err != nil {
+		t.Fatalf("Expected err != nil, got: %q", err)
+	}
+	assertAcquired(t, pools, mutex1)
+
+	if !mutex1.Valid() {
+		t.Fatalf("Expected a valid mutex")
+	}
+
+	mutex2 := rs.NewMutex(key)
+	err = mutex2.Lock()
+	if err == nil {
+		t.Fatalf("Expected err == nil, got: %q", err)
+	}
+}
+
 func newMockPools(n int, servers []*tempredis.Server) []Pool {
 	pools := []Pool{}
 	for _, server := range servers {


### PR DESCRIPTION
This addresses number 3 in http://antirez.com/news/101