### PR TITLE
Return errors from connections

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,13 @@
 module github.com/go-redsync/redsync
 
+go 1.13
+
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible
+	github.com/hashicorp/go-multierror v1.0.0
 	github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203
 )
 
-go 1.13
+// TODO: Remove this once this issue is addressed, or redigo no longer points to
+//       v2.0.0+incompatible, above: https://github.com/gomodule/redigo/issues/366
+replace github.com/gomodule/redigo => github.com/gomodule/redigo v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
+github.com/gomodule/redigo v1.7.0 h1:ZKld1VOtsGhAe37E7wMxEDgAlGM5dvFY+DiOhSkhP9Y=
+github.com/gomodule/redigo v1.7.0/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
 github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
+github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -45,7 +45,10 @@ func TestMutexExtend(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	expiries := getPoolExpiries(pools, mutex.name)
-	ok := mutex.Extend()
+	ok, err := mutex.Extend()
+	if err != nil {
+		t.Fatalf("Expected err == nil, got %q", err)
+	}
 	if !ok {
 		t.Fatalf("Expected ok == true, got %v", ok)
 	}


### PR DESCRIPTION
Fixes #44, fixes #19.

This does change the signatures for the `(*Mutex).Extend()` and `(*Mutex).Unlock()` methods (both now return errors), so tagging a new major version would be recommended.