### PR TITLE
Update import path to v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
+---
 language: go
+
 go:
   - "1.11"
   - "1.12"
   - "1.13"
   - "1.14"
+
+env:
+  global:
+    - GO111MODULE=on
+
 services:
   - redis-server

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/go-redsync/redsync
+module github.com/go-redsync/redsync/v2
 
 go 1.13
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	github.com/gomodule/redigo v2.0.0+incompatible
-	github.com/hashicorp/go-multierror v1.0.0
+	github.com/hashicorp/go-multierror v1.1.0
 	github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,8 @@
 github.com/gomodule/redigo v1.7.0 h1:ZKld1VOtsGhAe37E7wMxEDgAlGM5dvFY+DiOhSkhP9Y=
 github.com/gomodule/redigo v1.7.0/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
-github.com/gomodule/redigo v2.0.0+incompatible h1:K/R+8tc58AaqLkqG2Ol3Qk+DR/TlNuhuh457pBFPtt0=
-github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
-github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
+github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
+github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203 h1:QVqDTf3h2WHt08YuiTGPZLls0Wq99X9bWd0Q5ZSBesM=
 github.com/stvp/tempredis v0.0.0-20181119212430-b82af8480203/go.mod h1:oqN97ltKNihBbwlX8dLpwxCl3+HnXKV/R0e+sRLd9C8=


### PR DESCRIPTION
To make versioning work with Go modules one should update the import
path and thus package name in go.mod. This way users can update their
import paths by adding /v2 to use v2.x.x of the module. More information
about Go modules at https://blog.golang.org/v2-go-modules

---

To make the [v2.0.0](https://github.com/go-redsync/redsync/releases/tag/v2.0.0) work with go modules one must update `go.mod` to the proper import path. After merging this v2.0.0 should be re-released (or release v2.0.1).