### PR TITLE
Simplify recently added context support

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -122,7 +122,7 @@ func (m *Mutex) valid(ctx context.Context, pool redis.Pool) (bool, error) {
 		return false, err
 	}
 	defer conn.Close()
-	reply, err := conn.Get(ctx, m.name)
+	reply, err := conn.Get(m.name)
 	if err != nil {
 		return false, err
 	}
@@ -144,7 +144,7 @@ func (m *Mutex) acquire(ctx context.Context, pool redis.Pool, value string) (boo
 		return false, err
 	}
 	defer conn.Close()
-	reply, err := conn.SetNX(ctx, m.name, value, m.expiry)
+	reply, err := conn.SetNX(m.name, value, m.expiry)
 	if err != nil {
 		return false, err
 	}
@@ -165,7 +165,7 @@ func (m *Mutex) release(ctx context.Context, pool redis.Pool, value string) (boo
 		return false, err
 	}
 	defer conn.Close()
-	status, err := conn.Eval(ctx, deleteScript, m.name, value)
+	status, err := conn.Eval(deleteScript, m.name, value)
 	if err != nil {
 		return false, err
 	}
@@ -186,7 +186,7 @@ func (m *Mutex) touch(ctx context.Context, pool redis.Pool, value string, expiry
 		return false, err
 	}
 	defer conn.Close()
-	status, err := conn.Eval(ctx, touchScript, m.name, value, expiry)
+	status, err := conn.Eval(touchScript, m.name, value, expiry)
 	if err != nil {
 		return false, err
 	}

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -1,7 +1,6 @@
 package redsync
 
 import (
-	"context"
 	"strconv"
 	"testing"
 	"time"
@@ -127,11 +126,11 @@ func TestValid(t *testing.T) {
 func getPoolValues(pools []redis.Pool, name string) []string {
 	values := make([]string, len(pools))
 	for i, pool := range pools {
-		conn, err := pool.Get(context.TODO())
+		conn, err := pool.Get(nil)
 		if err != nil {
 			panic(err)
 		}
-		value, err := conn.Get(context.TODO(), name)
+		value, err := conn.Get(name)
 		if err != nil {
 			panic(err)
 		}
@@ -144,11 +143,11 @@ func getPoolValues(pools []redis.Pool, name string) []string {
 func getPoolExpiries(pools []redis.Pool, name string) []int {
 	expiries := make([]int, len(pools))
 	for i, pool := range pools {
-		conn, err := pool.Get(context.TODO())
+		conn, err := pool.Get(nil)
 		if err != nil {
 			panic(err)
 		}
-		expiry, err := conn.PTTL(context.TODO(), name)
+		expiry, err := conn.PTTL(name)
 		if err != nil {
 			panic(err)
 		}
@@ -165,11 +164,11 @@ func clogPools(pools []redis.Pool, mask int, mutex *Mutex) int {
 			n++
 			continue
 		}
-		conn, err := pool.Get(context.TODO())
+		conn, err := pool.Get(nil)
 		if err != nil {
 			panic(err)
 		}
-		_, err = conn.Set(context.TODO(), mutex.name, "foobar")
+		_, err = conn.Set(mutex.name, "foobar")
 		if err != nil {
 			panic(err)
 		}

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -14,11 +14,11 @@ type Pool interface {
 }
 
 type Conn interface {
-	Get(ctx context.Context, name string) (string, error)
-	Set(ctx context.Context, name string, value string) (bool, error)
-	SetNX(ctx context.Context, name string, value string, expiry time.Duration) (bool, error)
-	Eval(ctx context.Context, script *Script, keysAndArgs ...interface{}) (interface{}, error)
-	PTTL(ctx context.Context, name string) (time.Duration, error)
+	Get(name string) (string, error)
+	Set(name string, value string) (bool, error)
+	SetNX(name string, value string, expiry time.Duration) (bool, error)
+	Eval(script *Script, keysAndArgs ...interface{}) (interface{}, error)
+	PTTL(name string) (time.Duration, error)
 	Close() error
 }
 


### PR DESCRIPTION
The excellent idea of passing context when getting the connection by @bancek actually allows us to simplify (reverse) most of my original context support changes! Context only needs to be passed when creating the `Conn`, so no need for a context argument on every `Conn` member function.

This PR simplifies context passing and also fixes nil-context errors when using the original non-context aware `Mutex` APIs. There's no breaking changes (now that v4 is out there), it just simplifies the internals.

I was going to try and get this pushed before #54 #55 #56 were merged but you beat me to it @hjr265. Better late than never!