### PR TITLE
fixed: redis return int64 0 not equal golang int 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dump.rdb
 .idea
+vendor

--- a/examples/goredis/main.go
+++ b/examples/goredis/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	goredislib "github.com/go-redis/redis"
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/goredis"
@@ -31,5 +32,10 @@ func main() {
 
 	if _, err = mutex.Unlock(); err != nil {
 		panic(err)
+	}
+	if _, err = mutex.Unlock(); err != nil {
+		if !errors.Is(err, redsync.ErrTryToReleaseOthersLock) {
+			panic(err)
+		}
 	}
 }

--- a/examples/goredis/v7/main.go
+++ b/examples/goredis/v7/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-
+	"errors"
 	goredislib "github.com/go-redis/redis/v7"
 	"github.com/go-redsync/redsync/v4"
 	"github.com/go-redsync/redsync/v4/redis/goredis/v7"
@@ -34,5 +34,10 @@ func main() {
 
 	if _, err := mutex.UnlockContext(ctx); err != nil {
 		panic(err)
+	}
+	if _, err = mutex.Unlock(); err != nil {
+		if !errors.Is(err, redsync.ErrTryToReleaseOthersLock) {
+			panic(err)
+		}
 	}
 }

--- a/examples/goredis/v8/main.go
+++ b/examples/goredis/v8/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 
 	goredislib "github.com/go-redis/redis/v8"
 	"github.com/go-redsync/redsync/v4"
@@ -34,5 +35,10 @@ func main() {
 
 	if _, err := mutex.UnlockContext(ctx); err != nil {
 		panic(err)
+	}
+	if _, err = mutex.Unlock(); err != nil {
+		if !errors.Is(err, redsync.ErrTryToReleaseOthersLock) {
+			panic(err)
+		}
 	}
 }


### PR DESCRIPTION
redis will return int64 val, but golang is int val, the release function will always return true even if release other's lock.