### PR TITLE
fix: go-redis use redis.Cmdable interface

### DIFF
--- a/examples/goredis/v8_cluster/main.go
+++ b/examples/goredis/v8_cluster/main.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"context"
+
+	goredislib "github.com/go-redis/redis/v8"
+	"github.com/go-redsync/redsync/v4"
+	"github.com/go-redsync/redsync/v4/redis/goredis/v8"
+	"github.com/stvp/tempredis"
+)
+
+func main() {
+	server, err := tempredis.Start(tempredis.Config{})
+	if err != nil {
+		panic(err)
+	}
+	defer server.Term()
+	clusterSlots := func(ctx context.Context) ([]goredislib.ClusterSlot, error) {
+		slots := []goredislib.ClusterSlot{{
+				Start: 0,
+				End:   16383,
+				Nodes: []goredislib.ClusterNode{{Addr: server.Socket()}, {Addr: server.Socket()}}},
+		}
+		return slots, nil
+	}
+
+	redisCluster := goredislib.NewClusterClient(&goredislib.ClusterOptions{
+		ClusterSlots:  clusterSlots,
+		RouteRandomly: true,
+	})
+
+	pool := goredis.NewPool(redisCluster)
+
+	rs := redsync.New(pool)
+
+	mutex := rs.NewMutex("test-redsync")
+	ctx := context.Background()
+
+	if err := mutex.LockContext(ctx); err != nil {
+		panic(err)
+	}
+
+	if _, err := mutex.UnlockContext(ctx); err != nil {
+		panic(err)
+	}
+}

--- a/redis/goredis/v8/goredis.go
+++ b/redis/goredis/v8/goredis.go
@@ -10,22 +10,22 @@ import (
 )
 
 type pool struct {
-	delegate *redis.Client
+	delegate redis.Cmdable
 }
 
 func (p *pool) Get(ctx context.Context) (redsyncredis.Conn, error) {
 	if ctx == nil {
-		ctx = p.delegate.Context()
+		ctx = context.Background()
 	}
 	return &conn{p.delegate, ctx}, nil
 }
 
-func NewPool(delegate *redis.Client) redsyncredis.Pool {
+func NewPool(delegate redis.Cmdable) redsyncredis.Pool {
 	return &pool{delegate}
 }
 
 type conn struct {
-	delegate *redis.Client
+	delegate redis.Cmdable
 	ctx      context.Context
 }
 
@@ -68,13 +68,6 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 func (c *conn) Close() error {
 	// Not needed for this library
 	return nil
-}
-
-func (c *conn) _context(ctx context.Context) context.Context {
-	if ctx != nil {
-		return ctx
-	}
-	return c.delegate.Context()
 }
 
 func noErrNil(err error) error {


### PR DESCRIPTION
replace `redis.Client` with `redis.Cmdable` interface     

https://github.com/go-redsync/redsync/issues/52