### PR TITLE
Fix Extend and Unlock

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -169,7 +169,7 @@ func (m *Mutex) release(ctx context.Context, pool redis.Pool, value string) (boo
 	if err != nil {
 		return false, err
 	}
-	return status != 0, nil
+	return status != int64(0), nil
 }
 
 var touchScript = redis.NewScript(1, `
@@ -190,7 +190,7 @@ func (m *Mutex) touch(ctx context.Context, pool redis.Pool, value string, expiry
 	if err != nil {
 		return false, err
 	}
-	return status != "ERR", nil
+	return status != int64(0), nil
 }
 
 func (m *Mutex) actOnPoolsAsync(actFn func(redis.Pool) (bool, error)) (int, error) {

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -66,6 +66,58 @@ func TestMutexExtend(t *testing.T) {
 	}
 }
 
+func TestMutexExtendExpired(t *testing.T) {
+	for k, v := range makeCases(8) {
+		t.Run(k, func(t *testing.T) {
+			mutexes := newTestMutexes(v.pools, "test-mutex-extend", 1)
+			mutex := mutexes[0]
+			mutex.expiry = 500 * time.Millisecond
+
+			err := mutex.Lock()
+			if err != nil {
+				t.Fatalf("mutex lock failed: %s", err)
+			}
+			defer mutex.Unlock()
+
+			time.Sleep(1 * time.Second)
+
+			ok, err := mutex.Extend()
+			if err != nil {
+				t.Fatalf("mutex extend failed: %s", err)
+			}
+			if ok {
+				t.Fatalf("Expected ok == false, got %v", ok)
+			}
+		})
+	}
+}
+
+func TestMutexUnlockExpired(t *testing.T) {
+	for k, v := range makeCases(8) {
+		t.Run(k, func(t *testing.T) {
+			mutexes := newTestMutexes(v.pools, "test-mutex-extend", 1)
+			mutex := mutexes[0]
+			mutex.expiry = 500 * time.Millisecond
+
+			err := mutex.Lock()
+			if err != nil {
+				t.Fatalf("mutex lock failed: %s", err)
+			}
+			defer mutex.Unlock()
+
+			time.Sleep(1 * time.Second)
+
+			ok, err := mutex.Unlock()
+			if err != nil {
+				t.Fatalf("mutex unlock failed: %s", err)
+			}
+			if ok {
+				t.Fatalf("Expected ok == false, got %v", ok)
+			}
+		})
+	}
+}
+
 func TestMutexQuorum(t *testing.T) {
 	for k, v := range makeCases(4) {
 		t.Run(k, func(t *testing.T) {


### PR DESCRIPTION
Extend and Unlock do not work correctly if the lock expired.

In d2c5922 touch script was changed to return `0` instead of `"ERR"` in case of an error.

This was later broken in https://github.com/go-redsync/redsync/commit/3359663d03d3f72e1156ded3137d19f25fbdf18a#diff-d24f408f63b6b998a317403c06129658f576dd0ca1b01b59b331513804886428R161

But that does not really matter because comparing with `0` was not working correctly anyway because the result was `int64(0)` and the compared value was `int(0)` (and `(interface{})(int64(0)) != int(0)`).
