### PR TITLE
Use UniversalClient instead of Client

### DIFF
--- a/redis/goredis/v8/goredis.go
+++ b/redis/goredis/v8/goredis.go
@@ -10,7 +10,7 @@ import (
 )
 
 type pool struct {
-	delegate *redis.Client
+	delegate redis.UniversalClient
 }
 
 func (p *pool) Get(ctx context.Context) (redsyncredis.Conn, error) {
@@ -20,12 +20,12 @@ func (p *pool) Get(ctx context.Context) (redsyncredis.Conn, error) {
 	return &conn{p.delegate, ctx}, nil
 }
 
-func NewPool(delegate *redis.Client) redsyncredis.Pool {
+func NewPool(delegate redis.UniversalClient) redsyncredis.Pool {
 	return &pool{delegate}
 }
 
 type conn struct {
-	delegate *redis.Client
+	delegate redis.UniversalClient
 	ctx      context.Context
 }
 


### PR DESCRIPTION
The current V8 implementation of `redsync` expects a [single-node Redis Client](https://github.com/go-redis/redis/blob/d4f01eda2825ce453eace6d8cbd2fe500714645d/redis.go#L558).  This means those of us using a [FailoverClient](https://github.com/go-redis/redis/blob/d4f01eda2825ce453eace6d8cbd2fe500714645d/sentinel.go#L159) or [ClusteredClient](https://github.com/go-redis/redis/blob/d4f01eda2825ce453eace6d8cbd2fe500714645d/cluster.go#L687) can't use `redsync`.  This is easily fixed by using `go-redis's` [UniversalClient](https://github.com/go-redis/redis/blob/master/universal.go#L199) interface which supports all three `go-redis` client implementations.