### PR TITLE
Respect the context when waiting in LockContext()

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -63,11 +63,7 @@ func (m *Mutex) LockContext(ctx context.Context) error {
 			select {
 			case <-ctx.Done():
 				// Exit early if the context is done.
-				if ctx.Err() != nil {
-					return ErrFailed
-				}
-				// From the context docs, "Done may return nil if this context can never be canceled."
-				// So we also fall-through here, since we may have an un-cancelable context.
+				return ErrFailed
 			case <-time.After(m.delayFunc(i)):
 				// Fall-through when the delay timer completes.
 			}

--- a/mutex.go
+++ b/mutex.go
@@ -49,6 +49,10 @@ func (m *Mutex) Lock() error {
 
 // Lock locks m. In case it returns an error on failure, you may retry to acquire the lock by calling this method again.
 func (m *Mutex) LockContext(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	value, err := m.genValueFunc()
 	if err != nil {
 		return err

--- a/mutex.go
+++ b/mutex.go
@@ -56,7 +56,17 @@ func (m *Mutex) LockContext(ctx context.Context) error {
 
 	for i := 0; i < m.tries; i++ {
 		if i != 0 {
-			time.Sleep(m.delayFunc(i))
+			select {
+			case <-ctx.Done():
+				// Exit early if the context is done.
+				if ctx.Err() != nil {
+					return ErrFailed
+				}
+				// From the context docs, "Done may return nil if this context can never be canceled."
+				// So we also fall-through here, since we may have an un-cancelable context.
+			case <-time.After(m.delayFunc(i)):
+				// Fall-through when the delay timer completes.
+			}
 		}
 
 		start := time.Now()


### PR DESCRIPTION
This ensures that the LockContext() method will exit
in a more timely fashion in the case of context cancellation.