### PR TITLE
Fix ExtendContext, and export until for client to check the validity of the acquired lock.

### DIFF
--- a/error.go
+++ b/error.go
@@ -3,3 +3,4 @@ package redsync
 import "errors"
 
 var ErrFailed = errors.New("redsync: failed to acquire lock")
+var ErrExtendFailed = errors.New("redsync: failed to extend lock")


### PR DESCRIPTION
I propose 2 changes.

### Fix ExtendContext to check validity time and update `until`.

As explained [here](https://redis.io/topics/distlock), we need check validity time.

> The client should only consider the lock re-acquired if it was able to extend the lock into the majority of instances, and within the validity time (basically the algorithm to use is very similar to the one used when acquiring the lock).

### Add `Until()` to export `until`

To export `until` is useful for client to check the validity of the acquired lock.
Furthermore, I think there is a potential bug in current implementation of `ValidContext/Valid`.  I'm going to create an issue about that soon.