### PR TITLE
set timeout for request to Redis when trying to acquire a lock

### DIFF
--- a/mutex_test.go
+++ b/mutex_test.go
@@ -258,14 +258,15 @@ func newTestMutexes(pools []redis.Pool, name string, n int) []*Mutex {
 	mutexes := make([]*Mutex, n)
 	for i := 0; i < n; i++ {
 		mutexes[i] = &Mutex{
-			name:         name,
-			expiry:       8 * time.Second,
-			tries:        32,
-			delayFunc:    func(tries int) time.Duration { return 500 * time.Millisecond },
-			genValueFunc: genValue,
-			factor:       0.01,
-			quorum:       len(pools)/2 + 1,
-			pools:        pools,
+			name:          name,
+			expiry:        8 * time.Second,
+			tries:         32,
+			delayFunc:     func(tries int) time.Duration { return 500 * time.Millisecond },
+			genValueFunc:  genValue,
+			driftFactor:   0.01,
+			timeoutFactor: 0.05,
+			quorum:        len(pools)/2 + 1,
+			pools:         pools,
 		}
 	}
 	return mutexes

--- a/redsync.go
+++ b/redsync.go
@@ -33,10 +33,11 @@ func (r *Redsync) NewMutex(name string, options ...Option) *Mutex {
 		delayFunc: func(tries int) time.Duration {
 			return time.Duration(rand.Intn(maxRetryDelayMilliSec-minRetryDelayMilliSec)+minRetryDelayMilliSec) * time.Millisecond
 		},
-		genValueFunc: genValue,
-		factor:       0.01,
-		quorum:       len(r.pools)/2 + 1,
-		pools:        r.pools,
+		genValueFunc:  genValue,
+		driftFactor:   0.01,
+		timeoutFactor: 0.05,
+		quorum:        len(r.pools)/2 + 1,
+		pools:         r.pools,
 	}
 	for _, o := range options {
 		o.Apply(m)
@@ -90,7 +91,14 @@ func WithRetryDelayFunc(delayFunc DelayFunc) Option {
 // WithDriftFactor can be used to set the clock drift factor.
 func WithDriftFactor(factor float64) Option {
 	return OptionFunc(func(m *Mutex) {
-		m.factor = factor
+		m.driftFactor = factor
+	})
+}
+
+// WithTimeoutFactor can be used to set the timeout factor.
+func WithTimeoutFactor(factor float64) Option {
+	return OptionFunc(func(m *Mutex) {
+		m.timeoutFactor = factor
 	})
 }
 


### PR DESCRIPTION
# What  I did
https://redis.io/topics/distlock#the-redlock-algorithm says

> It tries to acquire the lock in all the N instances sequentially, using the same key name and random value in all the instances. During step 2, when setting the lock in each instance, the client uses a timeout which is small compared to the total lock auto-release time in order to acquire it. For example if the auto-release time is 10 seconds, the timeout could be in the ~ 5-50 milliseconds range. This prevents the client from remaining blocked for a long time trying to talk with a Redis node which is down: if an instance is not available, we should try to talk with the next instance ASAP.


Current Implementation does not support this timeout, I think this timeout is very important to liveness property of redlock, so I create a patch to support this timeout.


# How did I test?
I tested on my docker environment.
I prepared 3 Redis masters, which hosts are `kvs1`,`kvs2`,and `kvs3`. To simulate network partition between client and one node, I executed command as below on app container.

```
iptables -A INPUT -p tcp -s 172.19.0.3  -j DROP
```

And, I inserted temporary `log.Printf(" result:%+v\n", r)` after https://github.com/go-redsync/redsync/blob/a74496664535407d83456dc4de3853716672a9d1/mutex.go#L261 to understand what happened clearly.

FYI

<details><summary>docker-compose.yml</summary><div>

```
version: '3'
services:
  kvs1:
    container_name: kvs1
    image: redis:4.0.10
    ports:
      - "6379:6379"
  kvs2:
    container_name: kvs2
    image: redis:4.0.10
    ports:
      - "6380:6379"
  kvs3:
    container_name: kvs3
    image: redis:4.0.10
    ports:
      - "6381:6379"
  app:
    container_name: api.local
    image: local-develop-environment
```

</div></details>

<details><summary>main.go on local-develop-environment</summary><div>

```
package main

import (
	"context"
	"fmt"
	"time"

	"github.com/go-redsync/redsync/v4"
	"github.com/go-redsync/redsync/v4/redis/goredis/v8"

	goredislib "github.com/go-redis/redis/v8"
)

func main() {
	client1 := goredislib.NewClient(&goredislib.Options{
		Addr:     "kvs1:6379",
		Password: "", // no password set
		DB:       0,  // use default DB
	})
	client2 := goredislib.NewClient(&goredislib.Options{
		Addr:     "kvs2:6379",
		Password: "", // no password set
		DB:       0,  // use default DB
	})
	client3 := goredislib.NewClient(&goredislib.Options{
		Addr:     "kvs3:6379",
		Password: "", // no password set
		DB:       0,  // use default DB
	})

	rs := redsync.New(
		goredis.NewPool(client1),
		goredis.NewPool(client2),
		goredis.NewPool(client3),
	)

	var ctx = context.Background()
	mutex := rs.NewMutex("test-redsync")
	var err error
	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
	// ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
	defer cancel()
	if err = mutex.LockContext(ctx); err != nil {
		panic(err)
	}
	fmt.Println("locked")
}
```

</div></details>

## before PR
When `context.WithTimeout(ctx, 30*time.Second)`, 

```
root@8b1dcc137130:~/go/src/github.com/redsync/examples/keiichi# go run .
2021/12/20 00:22:42 ------------------------
2021/12/20 00:22:42  result:{Status:true Err:<nil>}
2021/12/20 00:22:42  result:{Status:true Err:<nil>}
2021/12/20 00:23:02  result:{Status:false Err:dial tcp 172.19.0.3:6379: i/o timeout}
2021/12/20 00:23:02 ------------------------
2021/12/20 00:23:02 ------------------------
2021/12/20 00:23:02  result:{Status:false Err:<nil>}
2021/12/20 00:23:02  result:{Status:false Err:<nil>}
2021/12/20 00:23:12  result:{Status:false Err:context deadline exceeded}
2021/12/20 00:23:12 ------------------------
panic: redsync: failed to acquire lock

goroutine 1 [running]:
main.main()
	/root/go/src/github.com/redsync/examples/keiichi/main.go:43 +0x485
exit status 2
```

On my environment(ubuntu:16.04), `i/o timeout` occurred in 20 seconds.
This case, `n >= m.quorum` is true but `now.Before(until)` is false, so client failed to acquire lock forever. 

When `context.WithTimeout(ctx, 5*time.Second)`, 

```
root@8b1dcc137130:~/go/src/github.com/redsync/examples/keiichi# go run .
2021/12/20 00:24:40 ------------------------
2021/12/20 00:24:40  result:{Status:true Err:<nil>}
2021/12/20 00:24:40  result:{Status:true Err:<nil>}
2021/12/20 00:24:45  result:{Status:false Err:context deadline exceeded}
2021/12/20 00:24:45 ------------------------
locked
```
This case, both of `n >= m.quorum` and  `now.Before(until)` are true, client acquired lock even though client could not communicate with one master node.
But, client took 5 seconds to acquire lock, it is too long , and other clients have no chance to acquire a lock.


## after PR

```
root@8b1dcc137130:~/go/src/github.com/redsync/examples/keiichi# go run .
2021/12/20 01:47:19  result:{Status:true Err:<nil>}
2021/12/20 01:47:19  result:{Status:true Err:<nil>}
2021/12/20 01:47:19  result:{Status:false Err:context deadline exceeded}
locked
```

Client acquired  lock right away.

# Discussion
What default value of `timeoutFactor` is preferable?

Again, 
https://redis.io/topics/distlock#the-redlock-algorithm says

> For example if the auto-release time is 10 seconds, the timeout could be in the ~ 5-50 milliseconds range.

If I follow this guidelines, `timeoutFactor` should be 0.0005 - 0.005. But, I think  this setting is too aggressive.  

Even though client can overwrite `timeoutFactor` by calling `WithTimeoutFactor`, some library users  may not notice change in behavior.

Currently, I set the default value of  `timeoutFactor` to `0.05`.