### PR TITLE
Use strings.Contains for script error matching

### DIFF
--- a/redis/goredis/v8/goredis.go
+++ b/redis/goredis/v8/goredis.go
@@ -60,7 +60,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	}
 
 	v, err := c.delegate.EvalSha(c.ctx, script.Hash, keys, args...).Result()
-	if err != nil && strings.HasPrefix(err.Error(), "NOSCRIPT ") {
+	if err != nil && strings.Contains(err.Error(), "NOSCRIPT ") {
 		v, err = c.delegate.Eval(c.ctx, script.Src, keys, args...).Result()
 	}
 	return v, noErrNil(err)


### PR DESCRIPTION
## Summary
This package uses the `redis.UniversalClient` interface to call `EvalSha`, which weakens the assumption that missing script errors will be prefixed by "NOSCRIPT ". We should use `strings.Contains` rather than `strings.HasPrefix` in order to maintain the same behavior for clients that wrap errors coming from `go-redis/redis/v8`.

## Notes
Determining control flow based upon the content of error strings isn't great, but the go-redis/redis/v8 package doesn't give us a lot of options: it looks as though this functionality is more or less copied from the [go-redis/redis/v8 package](https://github.com/go-redis/redis/blob/master/script.go#L61). 