### PR TITLE
Use strings.Contains for script error matching

### DIFF
--- a/redis/goredis/v8/goredis.go
+++ b/redis/goredis/v8/goredis.go
@@ -60,7 +60,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	}
 
 	v, err := c.delegate.EvalSha(c.ctx, script.Hash, keys, args...).Result()
-	if err != nil && strings.HasPrefix(err.Error(), "NOSCRIPT ") {
+	if err != nil && strings.Contains(err.Error(), "NOSCRIPT ") {
 		v, err = c.delegate.Eval(c.ctx, script.Src, keys, args...).Result()
 	}
 	return v, noErrNil(err)


### PR DESCRIPTION
## Summary
We use the `redis.UniversalClient` interface to call `EvalSha`, running the locking script. When this is run for the first time (or after scripts are flushed), redis returns a "NOSCRIPT" error. We handle these cases by checking for the "NOSCRIPT" error and calling `Eval` (thereby loading the script). The aforementioned error is detected by using `errors.HasPrefix("NOSCRIPT ")`, which will fail for clients which modify their error strings with prefixes. We should use `errors.Contains("NOSCRIPT ")` to handle these clients.

## Notes
Determining control flow based upon the content of error strings isn't great, but the go-redis/redis/v8 package doesn't give us a lot of options: it looks as though this functionality is more or less copied from the [go-redis/redis/v8 package](https://github.com/go-redis/redis/blob/master/script.go#L61). 

This change is only for go-redis/v8. The use of `strings.HasPrefix(...)` for redigo, go-redis, and go-redis/v7 has not been changed as a part of this pull-request because they use concrete types: `redigo.Pool` and `redis.Client`, respectively.