### PR TITLE
Add node information in error

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,9 @@
 package redsync
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // ErrFailed is the error resulting if Redsync fails to acquire the lock after
 // exhausting all retries.
@@ -9,3 +12,32 @@ var ErrFailed = errors.New("redsync: failed to acquire lock")
 // ErrExtendFailed is the error resulting if Redsync fails to extend the
 // lock.
 var ErrExtendFailed = errors.New("redsync: failed to extend lock")
+
+// ErrTaken happens when the lock is already taken in a quorum on nodes.
+type ErrTaken struct {
+	Nodes []int
+}
+
+func (err ErrTaken) Error() string {
+	return fmt.Sprintf("lock already taken, locked nodes: %v", err.Nodes)
+}
+
+// ErrNodeTaken is the error resulting if the lock is already taken in one of
+// the cluster's nodes
+type ErrNodeTaken struct {
+	Node int
+}
+
+func (err ErrNodeTaken) Error() string {
+	return fmt.Sprintf("node #%d: lock already taken", err.Node)
+}
+
+// A RedisError is an error communicating with one of the Redis nodes.
+type RedisError struct {
+	Node int
+	Err  error
+}
+
+func (err RedisError) Error() string {
+	return fmt.Sprintf("node #%d: %s", err.Node, err.Err)
+}


### PR DESCRIPTION
First things first, thank you very much for the library.

2 proposed changes:

### Add more information to errors
Current redsync errors don't provide too much information to the clients. Let's add a node identifier to de error message and more error types for a better error description.

### Return acquire error in the lock operation
Right now, we are returning `release` errors during lock operation. I think it would make more sense to return the `acquire` errors, to expose why the lock was not able to be taken.

NOTE: with this current approach, in case the lock was already taken in all nodes, it wouldn't do all the retries as in the first iteration, `n=0` and we would return the `ErrTaken`.