### PR TITLE
feat: mixin mutex with in-process and cross-process lock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/go-redis/redis/v7 v7.4.0
 	github.com/go-redis/redis/v8 v8.11.4
 	github.com/gomodule/redigo v1.8.2
-	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/redis/go-redis/v9 v9.0.2
 	github.com/rueian/rueidis v0.0.93

--- a/go.sum
+++ b/go.sum
@@ -51,9 +51,8 @@ github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
-github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/mixin_mutex.go
+++ b/mixin_mutex.go
@@ -1,0 +1,17 @@
+package redsync
+
+import "sync"
+
+var locksMap sync.Map
+
+type MixinMutex struct {
+	crossProcess *Mutex
+	inProcess    *sync.Mutex
+}
+
+// at any moment,only one goroutine can run Do func with distributed lock
+func (m *MixinMutex) Do(action func(l *Mutex) error) error {
+	m.inProcess.Lock()
+	defer m.inProcess.Unlock()
+	return action(m.crossProcess)
+}


### PR DESCRIPTION
When there are multiple goroutines calling a distributed lock, assuming 10, the execution time of one goroutine is 10ms, then the next 9 coroutine calls wait for 10ms, the second call is executed, and the next 8 coroutine calls Waiting for 20ms, and so on, the waiting time for subsequent executions is the cumulative execution time of previous goroutine calls, then the timeout time of subsequent goroutines is uncertain. I think it would be better when there are multiple goroutine calls to a distributed lock, these calls should be queued in the process