### PR TITLE
docs: add project to user list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,6 @@ Below is a list of public, open source projects that use Redsync:
 
 - [Sourcegraph](https://github.com/sourcegraph/sourcegraph): Universal code search and intelligence platform. Uses Redsync in an internal cache implementation.
 - [Open Match](https://github.com/googleforgames/open-match) by Google: Flexible, extensible, and scalable video game matchmaking. Uses Redsync with its state store implementation.
+- [Gocron](https://github.com/go-co-op/gocron) by go-co-op: gocron is a job distributed scheduling package which lets you run Go functions at pre-determined intervals using a simple, human-friendly syntax. Uses Redsync with its distributed job scheduler implementation.
 
 If you are using Redsync in a project please send a pull request to add it to the list.


### PR DESCRIPTION
### summary

add gocron to user list of redsync in readme.md . gocron support multiple scheduler is deployed in cluster, only scheduler that get redis locker can run jobs.  

https://github.com/go-co-op/gocron#distributed-locker-implementations

https://github.com/go-co-op/gocron-redis-lock