### PR TITLE
fix: optimize redis performance

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -29,6 +29,7 @@ type Mutex struct {
 	genValueFunc func() (string, error)
 	value        string
 	until        time.Time
+	shuffle      bool
 
 	pools []redis.Pool
 }

--- a/redsync.go
+++ b/redsync.go
@@ -42,6 +42,9 @@ func (r *Redsync) NewMutex(name string, options ...Option) *Mutex {
 	for _, o := range options {
 		o.Apply(m)
 	}
+	if m.shuffle {
+		m.pools = randomPools(m.pools)
+	}
 	return m
 }
 
@@ -115,4 +118,20 @@ func WithValue(v string) Option {
 	return OptionFunc(func(m *Mutex) {
 		m.value = v
 	})
+}
+
+// WithShufflePools can be used to shuffle redis pools.
+// when the redis pools are shuffled, centralized access to redis is reduced in concurrent scenarios.
+func WithShufflePools(b bool) Option {
+	return OptionFunc(func(m *Mutex) {
+		m.shuffle = b
+	})
+}
+
+// randomPools shuffle redis pools.
+func randomPools(pools []redis.Pool) []redis.Pool {
+	rand.Shuffle(len(pools), func(i, j int) {
+		pools[i], pools[j] = pools[j], pools[i]
+	})
+	return pools
 }

--- a/redsync.go
+++ b/redsync.go
@@ -43,7 +43,7 @@ func (r *Redsync) NewMutex(name string, options ...Option) *Mutex {
 		o.Apply(m)
 	}
 	if m.shuffle {
-		m.pools = randomPools(m.pools)
+		randomPools(m.pools)
 	}
 	return m
 }
@@ -129,9 +129,8 @@ func WithShufflePools(b bool) Option {
 }
 
 // randomPools shuffle redis pools.
-func randomPools(pools []redis.Pool) []redis.Pool {
+func randomPools(pools []redis.Pool) {
 	rand.Shuffle(len(pools), func(i, j int) {
 		pools[i], pools[j] = pools[j], pools[i]
 	})
-	return pools
 }


### PR DESCRIPTION
### summary

When we use multiple redis pools to operate distributed locks, such as redis1, redis2, redis3.

In high concurrency scenarios, we always access redis according to the configured initialization order, first access redis1, then access redis2, and finally access redis 3.

We can disrupt the order of redis pools internally, so that the performance overhead of the redis server will be reduced. 😆

when the redis pools are disordered, centralized access to redis is reduced in concurrent scenarios.

<img width="1387" alt="image" src="https://github.com/go-redsync/redsync/assets/3785409/f363109c-6ec4-4ec7-aec9-1c47f36b8483">
