### PR TITLE
feat: add with fail fast mode

### DIFF
--- a/redsync.go
+++ b/redsync.go
@@ -125,8 +125,9 @@ func WithValue(v string) Option {
 	})
 }
 
-// With FailFast can be used to quickly acquire and release the locker. We do not need to wait for all redis response results.
-// As long as the quorum is met, it will be returned immediately, and requests that have not yet been returned will be processed asynchronously.
+// WithFailFast can be used to quickly acquire and release the locker when some redis servers are blocking.
+// We do not need to wait for all redis servers response. As long as the quorum is met, it will be returned immediately, and requests that have not yet been returned will be processed asynchronously.
+// The effect of this parameter is to achieve low latency, avoid redis blocking causing lock/unlock to not return for a long time.
 func WithFailFast(b bool) Option {
 	return OptionFunc(func(m *Mutex) {
 		m.failFast = b

--- a/redsync.go
+++ b/redsync.go
@@ -125,6 +125,14 @@ func WithValue(v string) Option {
 	})
 }
 
+// With FailFast can be used to quickly acquire and release the locker. We do not need to wait for all redis response results.
+// As long as the quorum is met, it will be returned immediately, and requests that have not yet been returned will be processed asynchronously.
+func WithFailFast(b bool) Option {
+	return OptionFunc(func(m *Mutex) {
+		m.failFast = b
+	})
+}
+
 // WithShufflePools can be used to shuffle Redis pools to reduce centralized access in concurrent scenarios.
 func WithShufflePools(b bool) Option {
 	return OptionFunc(func(m *Mutex) {

--- a/redsync.go
+++ b/redsync.go
@@ -125,8 +125,8 @@ func WithValue(v string) Option {
 	})
 }
 
-// WithFailFast can be used to quickly acquire and release the locker when some redis servers are blocking.
-// We do not need to wait for all redis servers response. As long as the quorum is met, it will be returned immediately, and requests that have not yet been returned will be processed asynchronously.
+// WithFailFast can be used to quickly acquire and release the locker.
+// When some redis servers are blocking, we do not need to wait for all redis servers response. as long as the quorum is met, it will be returned immediately.
 // The effect of this parameter is to achieve low latency, avoid redis blocking causing lock/unlock to not return for a long time.
 func WithFailFast(b bool) Option {
 	return OptionFunc(func(m *Mutex) {


### PR DESCRIPTION
### summary

When some redis servers are blocking, we do not need to wait for all redis servers response. as long as the quorum is met, it will be returned immediately.

<img width="842" alt="image" src="https://github.com/go-redsync/redsync/assets/3785409/e37c5c7a-de3d-4dea-baa8-fcb5516a8604">
