### PR TITLE
feat: add redis cluster mode

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"strconv"
 	"time"
 
 	"github.com/go-redsync/redsync/v4/redis"
@@ -31,6 +32,8 @@ type Mutex struct {
 	until        time.Time
 	shuffle      bool
 	failFast     bool
+	clusterMode  bool
+	keyCount     int
 
 	pools []redis.Pool
 }
@@ -105,8 +108,8 @@ func (m *Mutex) lockContext(ctx context.Context, tries int) error {
 		n, err := func() (int, error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Duration(int64(float64(m.expiry)*m.timeoutFactor)))
 			defer cancel()
-			return m.actOnPoolsAsync(func(pool redis.Pool) (bool, error) {
-				return m.acquire(ctx, pool, value)
+			return m.actOnPoolsAsync(func(name string, pool redis.Pool) (bool, error) {
+				return m.acquire(ctx, name, pool, value)
 			})
 		}()
 
@@ -120,8 +123,8 @@ func (m *Mutex) lockContext(ctx context.Context, tries int) error {
 		func() (int, error) {
 			ctx, cancel := context.WithTimeout(ctx, time.Duration(int64(float64(m.expiry)*m.timeoutFactor)))
 			defer cancel()
-			return m.actOnPoolsAsync(func(pool redis.Pool) (bool, error) {
-				return m.release(ctx, pool, value)
+			return m.actOnPoolsAsync(func(name string, pool redis.Pool) (bool, error) {
+				return m.release(ctx, name, pool, value)
 			})
 		}()
 		if i == m.tries-1 && err != nil {
@@ -139,8 +142,8 @@ func (m *Mutex) Unlock() (bool, error) {
 
 // UnlockContext unlocks m and returns the status of unlock.
 func (m *Mutex) UnlockContext(ctx context.Context) (bool, error) {
-	n, err := m.actOnPoolsAsync(func(pool redis.Pool) (bool, error) {
-		return m.release(ctx, pool, m.value)
+	n, err := m.actOnPoolsAsync(func(name string, pool redis.Pool) (bool, error) {
+		return m.release(ctx, name, pool, m.value)
 	})
 	if n < m.quorum {
 		return false, err
@@ -156,8 +159,8 @@ func (m *Mutex) Extend() (bool, error) {
 // ExtendContext resets the mutex's expiry and returns the status of expiry extension.
 func (m *Mutex) ExtendContext(ctx context.Context) (bool, error) {
 	start := time.Now()
-	n, err := m.actOnPoolsAsync(func(pool redis.Pool) (bool, error) {
-		return m.touch(ctx, pool, m.value, int(m.expiry/time.Millisecond))
+	n, err := m.actOnPoolsAsync(func(name string, pool redis.Pool) (bool, error) {
+		return m.touch(ctx, name, pool, m.value, int(m.expiry/time.Millisecond))
 	})
 	if n < m.quorum {
 		return false, err
@@ -186,13 +189,13 @@ func (m *Mutex) Valid() (bool, error) {
 //
 // Deprecated: Use Until instead. See https://github.com/go-redsync/redsync/issues/72.
 func (m *Mutex) ValidContext(ctx context.Context) (bool, error) {
-	n, err := m.actOnPoolsAsync(func(pool redis.Pool) (bool, error) {
-		return m.valid(ctx, pool)
+	n, err := m.actOnPoolsAsync(func(name string, pool redis.Pool) (bool, error) {
+		return m.valid(ctx, name, pool)
 	})
 	return n >= m.quorum, err
 }
 
-func (m *Mutex) valid(ctx context.Context, pool redis.Pool) (bool, error) {
+func (m *Mutex) valid(ctx context.Context, name string, pool redis.Pool) (bool, error) {
 	if m.value == "" {
 		return false, nil
 	}
@@ -201,7 +204,7 @@ func (m *Mutex) valid(ctx context.Context, pool redis.Pool) (bool, error) {
 		return false, err
 	}
 	defer conn.Close()
-	reply, err := conn.Get(m.name)
+	reply, err := conn.Get(name)
 	if err != nil {
 		return false, err
 	}
@@ -217,13 +220,13 @@ func genValue() (string, error) {
 	return base64.StdEncoding.EncodeToString(b), nil
 }
 
-func (m *Mutex) acquire(ctx context.Context, pool redis.Pool, value string) (bool, error) {
+func (m *Mutex) acquire(ctx context.Context, name string, pool redis.Pool, value string) (bool, error) {
 	conn, err := pool.Get(ctx)
 	if err != nil {
 		return false, err
 	}
 	defer conn.Close()
-	reply, err := conn.SetNX(m.name, value, m.expiry)
+	reply, err := conn.SetNX(name, value, m.expiry)
 	if err != nil {
 		return false, err
 	}
@@ -238,13 +241,13 @@ var deleteScript = redis.NewScript(1, `
 	end
 `)
 
-func (m *Mutex) release(ctx context.Context, pool redis.Pool, value string) (bool, error) {
+func (m *Mutex) release(ctx context.Context, name string, pool redis.Pool, value string) (bool, error) {
 	conn, err := pool.Get(ctx)
 	if err != nil {
 		return false, err
 	}
 	defer conn.Close()
-	status, err := conn.Eval(deleteScript, m.name, value)
+	status, err := conn.Eval(deleteScript, name, value)
 	if err != nil {
 		return false, err
 	}
@@ -259,33 +262,48 @@ var touchScript = redis.NewScript(1, `
 	end
 `)
 
-func (m *Mutex) touch(ctx context.Context, pool redis.Pool, value string, expiry int) (bool, error) {
+func (m *Mutex) touch(ctx context.Context, name string, pool redis.Pool, value string, expiry int) (bool, error) {
 	conn, err := pool.Get(ctx)
 	if err != nil {
 		return false, err
 	}
 	defer conn.Close()
-	status, err := conn.Eval(touchScript, m.name, value, expiry)
+	status, err := conn.Eval(touchScript, name, value, expiry)
 	if err != nil {
 		return false, err
 	}
 	return status != int64(0), nil
 }
 
-func (m *Mutex) actOnPoolsAsync(actFn func(redis.Pool) (bool, error)) (int, error) {
+func (m *Mutex) actOnPoolsAsync(actFn func(name string, pool redis.Pool) (bool, error)) (int, error) {
 	type result struct {
 		node     int
 		statusOK bool
 		err      error
 	}
 
-	ch := make(chan result, len(m.pools))
-	for node, pool := range m.pools {
-		go func(node int, pool redis.Pool) {
-			r := result{node: node}
-			r.statusOK, r.err = actFn(pool)
-			ch <- r
-		}(node, pool)
+	var ch chan result
+
+	if m.clusterMode && m.keyCount > 0 {
+		ch = make(chan result, m.keyCount)
+		for i := 0; i < m.keyCount; i++ {
+			name := m.name + "-" + strconv.Itoa(i)
+			i := i
+			go func() {
+				r := result{node: i}
+				r.statusOK, r.err = actFn(name, m.pools[0])
+				ch <- r
+			}()
+		}
+	} else {
+		ch = make(chan result, len(m.pools))
+		for node, pool := range m.pools {
+			go func(node int, pool redis.Pool) {
+				r := result{node: node}
+				r.statusOK, r.err = actFn(m.name, pool)
+				ch <- r
+			}(node, pool)
+		}
 	}
 
 	var (

--- a/redsync.go
+++ b/redsync.go
@@ -125,6 +125,22 @@ func WithValue(v string) Option {
 	})
 }
 
+// WithClusterMode
+func WithClusterMode(quorum, keyCount int) Option {
+	return OptionFunc(func(m *Mutex) {
+		if keyCount < quorum {
+			return
+		}
+		if keyCount <= 0 || quorum <= 0 {
+			return
+		}
+
+		m.quorum = quorum
+		m.keyCount = keyCount
+		m.clusterMode = true
+	})
+}
+
 // WithFailFast can be used to quickly acquire and release the lock.
 // When some Redis servers are blocking, we do not need to wait for responses from all the Redis servers response.
 // As long as the quorum is met, we can assume the lock is acquired. The effect of this parameter is to achieve low

--- a/redsync.go
+++ b/redsync.go
@@ -125,17 +125,16 @@ func WithValue(v string) Option {
 	})
 }
 
-// WithClusterMode
-func WithClusterMode(quorum, keyCount int) Option {
+// WithClusterMode can be used to call lock/unlock by redis pool in redis cluster.
+// When using redis cluster, the redis client pool is usually just one.
+// We can set the KeyCount number of keys, the key layout is {name}-{idx}, and request different redis according to the redis slot distribution probability.
+func WithClusterMode(keyCount int) Option {
 	return OptionFunc(func(m *Mutex) {
-		if keyCount < quorum {
-			return
-		}
-		if keyCount <= 0 || quorum <= 0 {
-			return
+		if keyCount <= 0 {
+			keyCount = 6
 		}
 
-		m.quorum = quorum
+		m.quorum = keyCount/2 + 1
 		m.keyCount = keyCount
 		m.clusterMode = true
 	})


### PR DESCRIPTION
### summary

<img width="1153" alt="image" src="https://github.com/go-redsync/redsync/assets/3785409/b36f94f8-d11b-4084-a399-405991ae4bf4">

When using redis cluster, the redis client pool is usually just one. We can set the KeyCount number of keys, the key layout is {name}-{idx}, and request different redis according to the redis slot distribution probability.

As the number of nodes in the redis cluster increases, key-{idx} will be distributed more evenly. When a sharded redis master goes down, the backup redis will switch the master role and join the cluster.

But, if all key-{idx} is on a slot, then the redis is down, then it is no different from a single redis instance.

I don’t know how other libraries implement redlock under redis cluster. 😅

What do you think would be better done?
