### PR TITLE
fix: add lock expired error

### DIFF
--- a/error.go
+++ b/error.go
@@ -13,6 +13,9 @@ var ErrFailed = errors.New("redsync: failed to acquire lock")
 // lock.
 var ErrExtendFailed = errors.New("redsync: failed to extend lock")
 
+// ErrLockAlreadyExpired is the error resulting if trying to unlock the lock which already expired.
+var ErrLockAlreadyExpired = errors.New("redsync: failed to unlock since lock is already expired")
+
 // ErrTaken happens when the lock is already taken in a quorum on nodes.
 type ErrTaken struct {
 	Nodes []int

--- a/error.go
+++ b/error.go
@@ -14,7 +14,7 @@ var ErrFailed = errors.New("redsync: failed to acquire lock")
 var ErrExtendFailed = errors.New("redsync: failed to extend lock")
 
 // ErrLockAlreadyExpired is the error resulting if trying to unlock the lock which already expired.
-var ErrLockAlreadyExpired = errors.New("redsync: failed to unlock since lock is already expired")
+var ErrLockAlreadyExpired = errors.New("redsync: failed to unlock, lock was already expired")
 
 // ErrTaken happens when the lock is already taken in a quorum on nodes.
 type ErrTaken struct {


### PR DESCRIPTION
### **Current:**

Currently, when unlocking a mutex whose lock has expired, an inaccurate error message `ErrTaken` is received, as `deleteScript` does not distinguish between a key not being found and that the key is already associated with another value. The error message states "lock already taken..." when it may not accurately reflect the situation.

### **To be:**

Add a new error called `ErrLockAlreadyExpired` with message "failed to unlock, lock was already expired".

Feel free to leave comments.