### PR TITLE
Perform a SET if extending fails

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -260,6 +260,8 @@ func (m *Mutex) release(ctx context.Context, pool redis.Pool, value string) (boo
 var touchScript = redis.NewScript(1, `
 	if redis.call("GET", KEYS[1]) == ARGV[1] then
 		return redis.call("PEXPIRE", KEYS[1], ARGV[2])
+	elseif redis.call("SET", KEYS[1], ARGV[1], "PX", ARGV[2], "NX") then
+		return 1
 	else
 		return 0
 	end


### PR DESCRIPTION
Hello!

We recently discovered a problem using it with 3 redises configured in-memory only. If one of those redises gets restarted, when one of our services try to extend the previous locked key we get an error saying that key doesn't exist in that redis, thanks to the other two we keep operating normally, since 2 is enough for the quorum, but then we are left with 2 redises for extending instead of 3. As soon as one of those working redises get restarted as well we lose all locks immediately, as there is only one left with data, which means extending can't be accomplished.

I made a small change in this MR to have the extend operation try to SET they key if extending the TTL fails. This way no matter if a redis restarts, it will be sync after extending the lock with the others. 

Let me kwon if this makes sense. If so, I can add some tests. 

Thanks! 