### PR TITLE
Improve extending

### DIFF
--- a/mutex_test.go
+++ b/mutex_test.go
@@ -139,7 +139,7 @@ func TestMutexExtend(t *testing.T) {
 	}
 }
 
-func TestMutexExtendExpired(t *testing.T) {
+func TestMutexExtendExpiredAcquiresLockAgain(t *testing.T) {
 	for k, v := range makeCases(8) {
 		t.Run(k, func(t *testing.T) {
 			mutexes := newTestMutexes(v.pools, k+"-test-mutex-extend", 1)
@@ -154,12 +154,9 @@ func TestMutexExtendExpired(t *testing.T) {
 
 			time.Sleep(1 * time.Second)
 
-			ok, err := mutex.Extend()
-			if err == nil {
-				t.Fatalf("mutex extend didn't fail")
-			}
-			if ok {
-				t.Fatalf("Expected ok == false, got %v", ok)
+			_, err = mutex.Extend()
+			if err != nil {
+				t.Fatalf("mutex didn't extend")
 			}
 		})
 	}

--- a/redsync.go
+++ b/redsync.go
@@ -87,6 +87,16 @@ func WithRetryDelay(delay time.Duration) Option {
 	})
 }
 
+// WithSetNXOnExtend improves extending logic to extend the key if exist
+// and if not, tries to set a new key in redis
+// Useful if your redises restart often and you want to reduce the chances of losing the lock
+// Read this MR for more info: https://github.com/go-redsync/redsync/pull/149
+func WithSetNXOnExtend() Option {
+	return OptionFunc(func(m *Mutex) {
+		m.setNXOnExtend = true
+	})
+}
+
 // WithRetryDelayFunc can be used to override default delay behavior.
 func WithRetryDelayFunc(delayFunc DelayFunc) Option {
 	return OptionFunc(func(m *Mutex) {


### PR DESCRIPTION
Hello!

We are heavy users of this library and it works great, however, there is a small improvement that would alleviate some pain in our case. Let me explain it:
- we have 3 redis in the pool, with no persistence.
- we extend the lock every short period of time, with the idea of rarely losing it. Due to the importance of our use case, it's critical for us to try to keep the lock in the same instance as much as possible.

We realized we are losing the lock too often, and the reason is this:
If one of them gets restarted or unavailable for some time (it happens), our service locks in two redises instead of 3 since it's enough for the quorum. That's expected, but the problem is that from now on we are extending with 2 redises instead of 3 (we can't extend the one that got restarted cause it's empty, no key there). It's now a matter of time until one of the two we use to extend gets restarted as well, we then lose all locks in that redis, as all operations to extend fail because there is only one instance with keys to be extended, the other two don't have them.

This MR fixes that by trying to "extend or lock" instead of just "extend". This way if one of the redis restarts we'll sync up quickly the keys and all of them will be operative for extending. The only way to lose a lock now is if two redises get restarted at the same time, which is very unlikely. 

Let me know if this makes sense.

Thank you!