### PR TITLE
Remove clean up on extend fail

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -290,14 +290,6 @@ func (m *Mutex) touch(ctx context.Context, pool redis.Pool, value string, expiry
 
 	status, err := conn.Eval(touchScript, m.name, value, expiry)
 	if err != nil {
-		// extend failed: clean up locks
-		_, _ = func() (int, error) {
-			ctx, cancel := context.WithTimeout(ctx, time.Duration(int64(float64(m.expiry)*m.timeoutFactor)))
-			defer cancel()
-			return m.actOnPoolsAsync(func(pool redis.Pool) (bool, error) {
-				return m.release(ctx, pool, value)
-			})
-		}()
 		return false, err
 	}
 	return status != int64(0), nil


### PR DESCRIPTION
Hello! 

This is a fix for https://github.com/go-redsync/redsync/pull/149. I realized the clean up I added is cancelling the parent context if any of the redises fail to extend (for example with a network error). This means in case of a single redis error we'll release a previously held lock even if we were able to extend in a quorum redises fine. 

I can add the release after the `actOnPoolAsync`, however, the complexity in the code is not worth the benefit. So I just removed the code that released locks in case of errors. Locks will anyway be released after TTL expires. 

Let me know if this makes sense.

Thanks!