### PR TITLE
feat: support errors.Is(), errors.As() in RedisError

### DIFF
--- a/error.go
+++ b/error.go
@@ -44,3 +44,11 @@ type RedisError struct {
 func (err RedisError) Error() string {
 	return fmt.Sprintf("node #%d: %s", err.Node, err.Err)
 }
+
+func (err RedisError) Is(target error) bool {
+	return errors.Is(err.Err, target)
+}
+
+func (err RedisError) As(target any) bool {
+	return errors.As(err.Err, target)
+}

--- a/error_test.go
+++ b/error_test.go
@@ -1,0 +1,63 @@
+package redsync
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestRedisErrorIs(t *testing.T) {
+	cases := map[string]error{
+		"defined_error":  ErrFailed,
+		"other_error":    errors.New("other error"),
+		"wrapping_error": fmt.Errorf("wrapping: %w", ErrFailed),
+	}
+
+	for k, v := range cases {
+
+		t.Run(k, func(t *testing.T) {
+			err := RedisError{
+				Node: 0,
+				Err:  v,
+			}
+
+			if !errors.Is(err, v) {
+				t.Errorf("errors.Is must be true")
+			}
+		})
+	}
+}
+
+func TestRedisErrorAs(t *testing.T) {
+	derr := dummyError{}
+
+	cases := map[string]error{
+		"simple_error":   derr,
+		"wrapping_error": fmt.Errorf("wrapping: %w", derr),
+	}
+
+	for k, v := range cases {
+
+		t.Run(k, func(t *testing.T) {
+			err := RedisError{
+				Node: 0,
+				Err:  v,
+			}
+
+			var target dummyError
+			if !errors.As(err, &target) {
+				t.Errorf("errors.As must be true")
+			}
+
+			if target != derr {
+				t.Errorf("Expected target == %q, got %q", derr, target)
+			}
+		})
+	}
+}
+
+type dummyError struct{}
+
+func (err dummyError) Error() string {
+	return "dummy"
+}


### PR DESCRIPTION
By this PR, internal errors wrapped by `redsync.RedisError` can be checked by `errors.Is()` and `errors.As()`. This helps errors handlings to check the error cause like below.

```go
if err := mutex.Lock(); err != nil {
	if errors.Is(err, syscall.ECONNREFUSED) { // connection refused error wraps this
		fmt.Printf("connection refused: %v\n", err)
	}
	fmt.Printf("unexpected: %v\n", err)
	return
}
```
