### PR TITLE
fix: lockContext tries

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -125,7 +125,7 @@ func (m *Mutex) lockContext(ctx context.Context, tries int) error {
 				return m.release(ctx, pool, value)
 			})
 		}()
-		if i == m.tries-1 && err != nil {
+		if i == tries-1 && err != nil {
 			return err
 		}
 	}

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -97,7 +97,7 @@ func TestMutexAlreadyLocked(t *testing.T) {
 			assertAcquired(ctx, t, v.pools, mutex1)
 
 			mutex2 := rs.NewMutex(key)
-			err = mutex2.Lock()
+			err = mutex2.TryLock()
 			var errTaken *ErrTaken
 			if !errors.As(err, &errTaken) {
 				t.Fatalf("mutex was not already locked: %s", err)


### PR DESCRIPTION
The lockContext method uses the wrong tries.