### PR TITLE
Use pointer receiver for type-defined errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -21,7 +21,7 @@ type ErrTaken struct {
 	Nodes []int
 }
 
-func (err ErrTaken) Error() string {
+func (err *ErrTaken) Error() string {
 	return fmt.Sprintf("lock already taken, locked nodes: %v", err.Nodes)
 }
 
@@ -31,7 +31,7 @@ type ErrNodeTaken struct {
 	Node int
 }
 
-func (err ErrNodeTaken) Error() string {
+func (err *ErrNodeTaken) Error() string {
 	return fmt.Sprintf("node #%d: lock already taken", err.Node)
 }
 
@@ -41,10 +41,10 @@ type RedisError struct {
 	Err  error
 }
 
-func (e RedisError) Error() string {
+func (e *RedisError) Error() string {
 	return fmt.Sprintf("node #%d: %s", e.Node, e.Err)
 }
 
-func (e RedisError) Unwrap() error {
+func (e *RedisError) Unwrap() error {
 	return e.Err
 }

--- a/error_test.go
+++ b/error_test.go
@@ -16,7 +16,7 @@ func TestRedisErrorIs(t *testing.T) {
 	for k, v := range cases {
 
 		t.Run(k, func(t *testing.T) {
-			err := RedisError{
+			err := &RedisError{
 				Node: 0,
 				Err:  v,
 			}
@@ -39,7 +39,7 @@ func TestRedisErrorAs(t *testing.T) {
 	for k, v := range cases {
 
 		t.Run(k, func(t *testing.T) {
-			err := RedisError{
+			err := &RedisError{
 				Node: 0,
 				Err:  v,
 			}

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -265,8 +265,11 @@ func TestMutexQuorum(t *testing.T) {
 					assertAcquired(ctx, t, v.pools, mutex)
 				} else {
 					err := mutex.Lock()
-					if errors.Is(err, &ErrNodeTaken{}) {
-						t.Fatalf("Expected err == %q, got %q", ErrNodeTaken{}, err)
+					target := &ErrNodeTaken{
+						Node: 0,
+					}
+					if errors.Is(err, target) {
+						t.Fatalf("Expected err == %q, got %q", target, err)
 					}
 				}
 			}


### PR DESCRIPTION
The old code use value receiver for type-defined errors like `ErrTaken`, it makes `ErrTaken` and `*ErrTaken` are both valid errors. 

When I saw the the value receiver, I thought the way to check errrors should be

```go
var target redsync.ErrTaken
if errors.As(err, &target) {
	// ...
}
```

Unfortunately, it didn't work. Since the code returned `&ErrTaken`.

https://github.com/go-redsync/redsync/blob/b292c9fb1fd21ee51789ca367a124194f8f66cf0/mutex.go#L327

---

And I also see mix-use of the two types in the repo, the test code uses `RedisError` as an error:
https://github.com/go-redsync/redsync/blob/b292c9fb1fd21ee51789ca367a124194f8f66cf0/error_test.go#L19-L22

But here it uses `*RedisError` as an error:

https://github.com/go-redsync/redsync/blob/b292c9fb1fd21ee51789ca367a124194f8f66cf0/mutex.go#L327

---

So, I believe it's a good idea to use pointer receiver for type-defined errors, just like most errors in golang standard packages like `url.Error` and `os.PathError`. It doesn't break anything, since the right ways to handle such errors are the same before or after this PR:

```go
var target *redsync.ErrTaken
if errors.As(err, &target) {
	// ...
}
```

