### PR TITLE
feat: add watchdog mechanism for automatic lock renewal

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -374,6 +374,7 @@ func (m *Mutex) startWatchdog() {
 			ok, err := m.ExtendContext(context.Background())
 			if !ok || err != nil {
 				log.Printf("Watchdog failed to extend lock: %v", err)
+				return
 			}
 		case <-m.stopWatchdog:
 			log.Println("Watchdog stopped")

--- a/redsync.go
+++ b/redsync.go
@@ -69,6 +69,12 @@ func WithExpiry(expiry time.Duration) Option {
 	})
 }
 
+func WithWatchdogTimeout(timeout time.Duration) Option {
+	return OptionFunc(func(m *Mutex) {
+		m.watchdogTimeout = timeout
+	})
+}
+
 // WithTries can be used to set the number of times lock acquire is attempted.
 // The default value is 32.
 func WithTries(tries int) Option {


### PR DESCRIPTION
Unable to Run Tests on macOS Due to `tempredis.Start` Returning `io.EOF`

I encountered an issue while running the test suite on macOS. The tests rely on `tempredis`, and in the `redsync_test.go:75 TestMain` function, the call to `tempredis.Start` returns an `io.EOF` error.  

From my understanding, this error seems expected in some scenarios, but I'm not entirely sure if this behavior is specific to macOS or if there might be another underlying issue.  

I wasn't able to proceed past this error to run the full test suite locally. I would appreciate any guidance or insights from the maintainers or others who have encountered this issue.  

Thank you!  

**Environment:**  
- **OS:** macOS Ventura Version 13.3 (22E252)
- **Redis Server:** Redis server v=7.0.2 sha=00000000:0 malloc=libc bits=64 build=50ced33b9e26b2a3
- **Go Version:** go version go1.23.4 darwin/arm64
- **Redsync Version:** master branch, commit id: b292c9fb1fd21ee51789ca367a124194f8f66cf0