### PR TITLE
use go1.22 loops

### DIFF
--- a/mutex.go
+++ b/mutex.go
@@ -83,7 +83,7 @@ func (m *Mutex) lockContext(ctx context.Context, tries int) error {
 	}
 
 	var timer *time.Timer
-	for i := 0; i < tries; i++ {
+	for i := range tries {
 		if i != 0 {
 			if timer == nil {
 				timer = time.NewTimer(m.delayFunc(i))

--- a/mutex_test.go
+++ b/mutex_test.go
@@ -250,7 +250,7 @@ func TestMutexQuorum(t *testing.T) {
 	ctx := context.Background()
 	for k, v := range makeCases(4) {
 		t.Run(k, func(t *testing.T) {
-			for mask := 0; mask < 1<<uint(len(v.pools)); mask++ {
+			for mask := range 1 << len(v.pools) {
 				mutexes := newTestMutexes(v.pools, k+"-test-mutex-partial-"+strconv.Itoa(mask), 1)
 				mutex := mutexes[0]
 				mutex.tries = 1
@@ -387,7 +387,7 @@ func clogPools(pools []redis.Pool, mask int, mutex *Mutex) int {
 
 func newTestMutexes(pools []redis.Pool, name string, n int) []*Mutex {
 	mutexes := make([]*Mutex, n)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		mutexes[i] = &Mutex{
 			name:          name + "-" + strconv.Itoa(i),
 			expiry:        8 * time.Second,

--- a/redis/goredis/goredis.go
+++ b/redis/goredis/goredis.go
@@ -55,7 +55,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	args := keysAndArgs
 
 	if script.KeyCount > 0 {
-		for i := 0; i < script.KeyCount; i++ {
+		for i := range script.KeyCount {
 			keys[i] = keysAndArgs[i].(string)
 		}
 

--- a/redis/goredis/v7/goredis.go
+++ b/redis/goredis/v7/goredis.go
@@ -58,7 +58,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	args := keysAndArgs
 
 	if script.KeyCount > 0 {
-		for i := 0; i < script.KeyCount; i++ {
+		for i := range script.KeyCount {
 			keys[i] = keysAndArgs[i].(string)
 		}
 		args = keysAndArgs[script.KeyCount:]

--- a/redis/goredis/v8/goredis.go
+++ b/redis/goredis/v8/goredis.go
@@ -53,7 +53,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	args := keysAndArgs
 
 	if script.KeyCount > 0 {
-		for i := 0; i < script.KeyCount; i++ {
+		for i := range script.KeyCount {
 			keys[i] = keysAndArgs[i].(string)
 		}
 		args = keysAndArgs[script.KeyCount:]

--- a/redis/goredis/v9/goredis.go
+++ b/redis/goredis/v9/goredis.go
@@ -53,7 +53,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	args := keysAndArgs
 
 	if script.KeyCount > 0 {
-		for i := 0; i < script.KeyCount; i++ {
+		for i := range script.KeyCount {
 			keys[i] = keysAndArgs[i].(string)
 		}
 		args = keysAndArgs[script.KeyCount:]

--- a/redis/rueidis/rueidis.go
+++ b/redis/rueidis/rueidis.go
@@ -55,7 +55,7 @@ func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (in
 	args := keysAndArgs
 
 	if script.KeyCount > 0 {
-		for i := 0; i < script.KeyCount; i++ {
+		for i := range script.KeyCount {
 			keys[i] = keysAndArgs[i].(string)
 		}
 		args = keysAndArgs[script.KeyCount:]

--- a/redsync_test.go
+++ b/redsync_test.go
@@ -73,7 +73,7 @@ const (
 )
 
 func TestMain(m *testing.M) {
-	for i := 0; i < ServerPoolSize*ServerPools; i++ {
+	for i := range ServerPoolSize * ServerPools {
 		server, err := tempredis.Start(tempredis.Config{
 			"port": strconv.Itoa(51200 + i),
 		})
@@ -108,7 +108,7 @@ func newMockPoolsRedigo(n int) []redis.Pool {
 
 	offset := RedigoBlock * ServerPoolSize
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		server := servers[i+offset]
 		pools[i] = redigo.NewPool(&redigolib.Pool{
 			MaxIdle:     3,
@@ -130,7 +130,7 @@ func newMockPoolsGoredis(n int) []redis.Pool {
 
 	offset := GoredisBlock * ServerPoolSize
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		client := goredislib.NewClient(&goredislib.Options{
 			Network: "unix",
 			Addr:    servers[i+offset].Socket(),
@@ -145,7 +145,7 @@ func newMockPoolsGoredisV7(n int) []redis.Pool {
 
 	offset := GoredisV7Block * ServerPoolSize
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		client := goredislib_v7.NewClient(&goredislib_v7.Options{
 			Network: "unix",
 			Addr:    servers[i+offset].Socket(),
@@ -160,7 +160,7 @@ func newMockPoolsGoredisV8(n int) []redis.Pool {
 
 	offset := GoredisV8Block * ServerPoolSize
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		client := goredislib_v8.NewClient(&goredislib_v8.Options{
 			Network: "unix",
 			Addr:    servers[i+offset].Socket(),
@@ -175,7 +175,7 @@ func newMockPoolsGoredisV9(n int) []redis.Pool {
 
 	offset := GoredisV9Block * ServerPoolSize
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		client := goredislib_v9.NewClient(&goredislib_v9.Options{
 			Network: "unix",
 			Addr:    servers[i+offset].Socket(),
@@ -190,7 +190,7 @@ func newMockPoolsRueidis(n int) []redis.Pool {
 
 	offset := RueidisBlock * ServerPoolSize
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		client, err := rueidislib.NewClient(rueidislib.ClientOption{
 			InitAddress: []string{"127.0.0.1:" + strconv.Itoa(51200+i+offset)},
 		})


### PR DESCRIPTION
This updates 3-clause range loops to use the Go 1.22 style range-over-int form.

This also removes mitigations for the closure-over-loop-var issue that existed prior to Go 1.22.

A local run of tests pass.

It's recommended to view this in "Hide whitespace" mode.