### PR TITLE
make pool shuffling avoid data races

### DIFF
--- a/redsync.go
+++ b/redsync.go
@@ -2,6 +2,7 @@ package redsync
 
 import (
 	"math/rand"
+	"slices"
 	"time"
 
 	"github.com/go-redsync/redsync/v4/redis"
@@ -43,6 +44,8 @@ func (r *Redsync) NewMutex(name string, options ...Option) *Mutex {
 		o.Apply(m)
 	}
 	if m.shuffle {
+		// Create a copy to avoid data races between concurrent locks.
+		m.pools = slices.Clone(m.pools)
 		randomPools(m.pools)
 	}
 	return m


### PR DESCRIPTION
The current base-branch behavior is that a shared backing array will be shuffled concurrently upon each mutex creation, which could lead to a data race on both the shuffling writes as well as subsequent reads.

As such, it could end up in a situation where pools get overwritten by a duplicate of another element, or at read time, might read pool C, then A, then (due to a racing shuffle) read C again, causing lock attempts to C, A, C instead of C, A, B.

This PR solves the issue by forcing a new pools backing array allocation for each new mutex when shuffling is requested. A hypothetically more ideal solution (though involving more work) would involve something like a random walk across a fixed slice, presuming that can be done without allocations.