### PR TITLE
fix redis-server not shutting down after tests

### DIFF
--- a/redsync_test.go
+++ b/redsync_test.go
@@ -73,6 +73,10 @@ const (
 )
 
 func TestMain(m *testing.M) {
+	os.Exit(testRunner(m))
+}
+
+func testRunner(m *testing.M) int {
 	for i := range ServerPoolSize * ServerPools {
 		server, err := tempredis.Start(tempredis.Config{
 			"port": strconv.Itoa(51200 + i),
@@ -85,7 +89,7 @@ func TestMain(m *testing.M) {
 		servers = append(servers, server)
 	}
 
-	os.Exit(m.Run())
+	return m.Run()
 }
 
 func TestRedsync(t *testing.T) {


### PR DESCRIPTION
This fixes an issue I introduced with #172, where the use of `os.Exit` would prevent the `defer`'d redis-server shutdowns from occurring.