### PR TITLE
Change hash function from SHA1 to SHA256

### DIFF
--- a/redis/redis.go
+++ b/redis/redis.go
@@ -2,7 +2,7 @@ package redis
 
 import (
 	"context"
-	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"io"
 	"time"
@@ -38,7 +38,7 @@ type Script struct {
 // SendHash methods.
 // Taken from https://github.com/gomodule/redigo/blob/46992b0f02f74066bcdfd9b03e33bc03abd10dc7/redis/script.go#L32-L41
 func NewScript(keyCount int, src string) *Script {
-	h := sha1.New()
+	h := sha256.New()
 	_, _ = io.WriteString(h, src)
 	return &Script{keyCount, src, hex.EncodeToString(h.Sum(nil))}
 }


### PR DESCRIPTION
FIP-140 mandates a move away from SHA1

Fixes https://github.com/go-redsync/redsync/issues/194