### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/redis/goredis/goredis.go
+++ b/redis/goredis/goredis.go
@@ -50,7 +50,7 @@ func (c *conn) PTTL(name string) (time.Duration, error) {
 	return expiry, noErrNil(err)
 }
 
-func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (interface{}, error) {
+func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...any) (any, error) {
 	keys := make([]string, script.KeyCount)
 	args := keysAndArgs
 

--- a/redis/goredis/v7/goredis.go
+++ b/redis/goredis/v7/goredis.go
@@ -53,7 +53,7 @@ func (c *conn) PTTL(name string) (time.Duration, error) {
 	return c.delegate.PTTL(name).Result()
 }
 
-func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (interface{}, error) {
+func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...any) (any, error) {
 	keys := make([]string, script.KeyCount)
 	args := keysAndArgs
 

--- a/redis/goredis/v8/goredis.go
+++ b/redis/goredis/v8/goredis.go
@@ -48,7 +48,7 @@ func (c *conn) PTTL(name string) (time.Duration, error) {
 	return c.delegate.PTTL(c.ctx, name).Result()
 }
 
-func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (interface{}, error) {
+func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...any) (any, error) {
 	keys := make([]string, script.KeyCount)
 	args := keysAndArgs
 

--- a/redis/goredis/v9/goredis.go
+++ b/redis/goredis/v9/goredis.go
@@ -48,7 +48,7 @@ func (c *conn) PTTL(name string) (time.Duration, error) {
 	return c.delegate.PTTL(c.ctx, name).Result()
 }
 
-func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (interface{}, error) {
+func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...any) (any, error) {
 	keys := make([]string, script.KeyCount)
 	args := keysAndArgs
 

--- a/redis/redigo/redigo.go
+++ b/redis/redigo/redigo.go
@@ -58,7 +58,7 @@ func (c *conn) PTTL(name string) (time.Duration, error) {
 	return time.Duration(expiry) * time.Millisecond, noErrNil(err)
 }
 
-func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (interface{}, error) {
+func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...any) (any, error) {
 	v, err := c.delegate.Do("EVALSHA", args(script, script.Hash, keysAndArgs)...)
 	if e, ok := err.(redis.Error); ok && strings.HasPrefix(string(e), "NOSCRIPT ") {
 		v, err = c.delegate.Do("EVAL", args(script, script.Src, keysAndArgs)...)
@@ -86,14 +86,14 @@ func noErrNil(err error) error {
 	return nil
 }
 
-func args(script *redsyncredis.Script, spec string, keysAndArgs []interface{}) []interface{} {
-	var args []interface{}
+func args(script *redsyncredis.Script, spec string, keysAndArgs []any) []any {
+	var args []any
 	if script.KeyCount < 0 {
-		args = make([]interface{}, 1+len(keysAndArgs))
+		args = make([]any, 1+len(keysAndArgs))
 		args[0] = spec
 		copy(args[1:], keysAndArgs)
 	} else {
-		args = make([]interface{}, 2+len(keysAndArgs))
+		args = make([]any, 2+len(keysAndArgs))
 		args[0] = spec
 		args[1] = script.KeyCount
 		copy(args[2:], keysAndArgs)

--- a/redis/redis.go
+++ b/redis/redis.go
@@ -15,7 +15,7 @@ type Conn interface {
 	Get(name string) (string, error)
 	Set(name string, value string) (bool, error)
 	SetNX(name string, value string, expiry time.Duration) (bool, error)
-	Eval(script *Script, keysAndArgs ...interface{}) (interface{}, error)
+	Eval(script *Script, keysAndArgs ...any) (any, error)
 	ScriptLoad(script *Script) error
 	PTTL(name string) (time.Duration, error)
 	Close() error

--- a/redis/rueidis/rueidis.go
+++ b/redis/rueidis/rueidis.go
@@ -50,7 +50,7 @@ func (c *conn) PTTL(name string) (time.Duration, error) {
 	return c.delegate.PTTL(c.ctx, name).Result()
 }
 
-func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (interface{}, error) {
+func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...any) (any, error) {
 	keys := make([]string, script.KeyCount)
 	args := keysAndArgs
 

--- a/redis/valkeygo/valkeygo.go
+++ b/redis/valkeygo/valkeygo.go
@@ -49,7 +49,7 @@ func (c *conn) PTTL(name string) (time.Duration, error) {
 	return c.delegate.PTTL(c.ctx, name).Result()
 }
 
-func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...interface{}) (interface{}, error) {
+func (c *conn) Eval(script *redsyncredis.Script, keysAndArgs ...any) (any, error) {
 	keys := make([]string, script.KeyCount)
 	args := keysAndArgs
 


### PR DESCRIPTION
Replaces all occurrences of `interface{}` with `any` in the redis package, modernizing the codebase for Go 1.18+.