### PR TITLE
docs: link generated API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ See the [examples](examples) folder for usage of each driver.
 
 ## Documentation
 
-- [Reference](https://godoc.org/github.com/go-redsync/redsync)
+- [Go package reference](https://pkg.go.dev/github.com/go-redsync/redsync/v4)
+- [Sourcey API browser](https://redsync-sourcey-docs.readthedocs.io/en/latest/)
+  provides package and symbol navigation generated from a pinned Redsync
+  source commit, with links back to the corresponding source lines.
 
 ## Usage
 


### PR DESCRIPTION
This change replaces the legacy `godoc.org` documentation link with a
project-named Read the Docs site generated from Redsync source by Sourcey:

https://redsync-sourcey-docs.readthedocs.io/en/latest/

The initial site is pinned to Redsync commit
`79f6ba24a8bf41f35141de700d410a06bb27622f`. It covers the root locking API,
Redis interfaces, and the go-redis, Redigo, Rueidis, and Valkey adapter
packages, with search and links back to the corresponding source lines.

The reproducible build source and generated static output are maintained at:

https://github.com/fengyangxxx/redsync-sourcey-docs

The documentation project is transferable. I can invite Redsync maintainers
to both the Read the Docs project and the backing repository so the project
can own future rebuilds or move the static output to a project-controlled
host.

Verification performed before opening this PR:

- Source commit: `79f6ba24a8bf41f35141de700d410a06bb27622f`
- Sourcey version: `3.6.3`
- Generated coverage: 21 pages, including 15 API package pages
- Inventory: 15 packages, 19 non-test Go files, 110 exported symbols
- Five page-to-source mappings checked against the pinned commit
- Root compile-only check and focused `redis/...` tests passed
- Full `go test ./...` requires the external `redis-server` binary, which is
  not installed in the documentation build environment

No library code or runtime dependency changes are included.
